### PR TITLE
Update django-setup-demo.sh

### DIFF
--- a/django-setup-demo.sh
+++ b/django-setup-demo.sh
@@ -3,6 +3,9 @@
 # install coffee-script dependencies (npm, node.js)
 sudo apt-get install npm nodejs
 
+# symbolically link nodejs to node so django can find it
+sudo ln -s /usr/bin/nodejs /usr/bin/node
+
 # install coffee-script
 sudo npm install -g coffee-script
 


### PR DESCRIPTION
This is an extra step I had to take when installing the program. Why not include it while you require sudo permissions anyway? Thread here: https://github.com/nodejs/node-v0.x-archive/issues/3911